### PR TITLE
Rewrite episteme:load-remotes to Support HTTPS and the SSH Flag

### DIFF
--- a/support.org
+++ b/support.org
@@ -234,9 +234,9 @@ e.g. =(:push some-list 1 2 3)=
   ;; files
   (setq epicenter/remotes-file (concat epicenter/remotes-path "/remotes.json"))
 #+end_src
-** useSSH
+** use-ssh
 #+begin_src emacs-lisp
-(setq episteme/useSSH (getenv useSSH))
+(setq episteme/use-ssh (getenv "useSSH"))
 #+end_src
 
 ** default keybinds
@@ -1827,19 +1827,55 @@ Set episteme/current-remote interactively.
 
 * epicenter
 ** internal
+*** get-remote-name
+#+begin_src emacs-lisp
+  (defun epicenter--get-remote-name (remote)
+    (->> remote (car) (symbol-name)))
+#+end_src
+
+*** get-remote-host
+#+begin_src emacs-lisp
+  (defun epicenter--get-remote-host (remote)
+    (->> remote (nth 1) (cdr)))
+#+end_src
+
+*** get-remote-path
+#+begin_src emacs-lisp
+  (defun epicenter--get-remote-path (remote)
+    (->> remote (nth 2) (cdr)))
+#+end_src
+
+*** get-remote-description
+#+begin_src emacs-lisp
+  (defun epicenter--get-remote-description (remote)
+    (->> remote (nth 3) (cdr)))
+#+end_src
+
+*** format-ssh-url
+#+begin_src emacs-lisp
+  (defun epicenter--format-ssh-url (host path)
+    (concat "git@" host ":" path))
+#+end_src
+
+*** format-https-url
+#+begin_src emacs-lisp
+  (defun epicenter--format-https-url (host path)
+    (concat "https://" host "/" path))
+#+end_src
+
 *** load-remotes
 #+begin_src emacs-lisp
   (defun epicenter:load-remotes ()
     (let ((remotes-map (json-read-file epicenter/remotes-file)))
-      (mapcar (lambda (remote)
-                (let ((name (symbol-name (car remote)))
-                      (url (if
-                               (symbol-value 'episteme/useSSH)
-                               (concat "git@" (cdr (nth 1 remote)) ":" (cdr (nth 2 remote)))
-                             (concat "https://" (cdr (nth 1 remote)) "/" (cdr (nth 2 remote)))))
-                      (description (cdr (nth 3 remote))))
-                  (list name url description)))
-                remotes-map)))
+      (--map (let* ((name (epicenter--get-remote-name it))
+                    (host (epicenter--get-remote-host it))
+                    (path (epicenter--get-remote-path it))
+                    (desc (epicenter--get-remote-description it))
+                    (url (if episteme/use-ssh
+                             (epicenter--format-ssh-url host path)
+                           (epicenter--format-https-url host path))))
+               (list name url desc))
+             remotes-map)))
 #+end_src
 
 *** compare-remote-urls

--- a/support.org
+++ b/support.org
@@ -1865,7 +1865,7 @@ Set episteme/current-remote interactively.
 
 *** load-remotes
 #+begin_src emacs-lisp
-  (defun epicenter:load-remotes ()
+  (defun epicenter--load-remotes ()
     (let ((remotes-map (json-read-file epicenter/remotes-file)))
       (--map (let* ((name (epicenter--get-remote-name it))
                     (host (epicenter--get-remote-host it))
@@ -1883,8 +1883,8 @@ Check every local remote against epicenter remotes.
 Gather a list of remotes whos urls are not the same.
 Each result should have the name, localUrl, and remoteUrl.
 #+begin_src emacs-lisp
-  (defun epicenter:compare-remote-urls ()
-    (let* ((remotes (epicenter:load-remotes))
+  (defun epicenter--compare-remote-urls ()
+    (let* ((remotes (epicenter--load-remotes))
            (remote-names (--map (car it) remotes))
            (local-remotes (episteme-get-remote-names))
            ;; calculate which local-remotes are also in remote-names
@@ -1909,7 +1909,7 @@ Each result should have the name, localUrl, and remoteUrl.
 
 *** pick-from
 #+begin_src emacs-lisp
-  (defun epicenter:pick-from (remotes &optional title)
+  (defun epicenter--pick-from (remotes &optional title)
     (helm :sources
           (helm-build-sync-source (or title "Pick a remote")
             :multiline t
@@ -1927,9 +1927,9 @@ Each result should have the name, localUrl, and remoteUrl.
 
 *** pick-remote
 #+begin_src emacs-lisp
-  (defun epicenter:pick-remote ()
+  (defun epicenter--pick-remote ()
     (interactive)
-    (let ((remotes (epicenter:load-remotes)))
+    (let ((remotes (epicenter--load-remotes)))
       (helm :sources (helm-build-sync-source "Pick an epicenter remote"
                        :multiline t
                        :candidates (mapcar (lambda (remote)
@@ -1954,7 +1954,7 @@ Each result should have the name, localUrl, and remoteUrl.
 #+begin_src emacs-lisp
   (defun epicenter-track-knowlegebase ()
     (interactive)
-    (let ((remote (epicenter:pick-remote)))
+    (let ((remote (epicenter--pick-remote)))
       (if remote
           (let ((name (nth 0 remote))
                 (url (nth 1 remote)))
@@ -1966,9 +1966,9 @@ Each result should have the name, localUrl, and remoteUrl.
 #+begin_src emacs-lisp
   (defun epicenter-compare-remotes ()
     (interactive)
-    (let ((remotes (epicenter:compare-remote-urls)))
+    (let ((remotes (epicenter--compare-remote-urls)))
       (if remotes
-          (let* ((choice (epicenter:pick-from remotes))
+          (let* ((choice (epicenter--pick-from remotes))
                  (name (nth 0 choice))
                  (url (nth 1 choice)))
             (episteme-set-remote-url name url)

--- a/support.org
+++ b/support.org
@@ -234,6 +234,10 @@ e.g. =(:push some-list 1 2 3)=
   ;; files
   (setq epicenter/remotes-file (concat epicenter/remotes-path "/remotes.json"))
 #+end_src
+** useSSH
+#+begin_src emacs-lisp
+(setq episteme/useSSH (getenv useSSH))
+#+end_src
 
 ** default keybinds
 #+begin_src emacs-lisp
@@ -1823,15 +1827,17 @@ Set episteme/current-remote interactively.
 
 * epicenter
 ** internal
-
 *** load-remotes
 #+begin_src emacs-lisp
   (defun epicenter:load-remotes ()
     (let ((remotes-map (json-read-file epicenter/remotes-file)))
       (mapcar (lambda (remote)
                 (let ((name (symbol-name (car remote)))
-                      (url (cdr (nth 1 remote)))
-                      (description (cdr (nth 2 remote))))
+                      (url (if
+                               (symbol-value 'episteme/useSSH)
+                               (concat "git@" (cdr (nth 1 remote)) ":" (cdr (nth 2 remote)))
+                             (concat "https://" (cdr (nth 1 remote)) "/" (cdr (nth 2 remote)))))
+                      (description (cdr (nth 3 remote))))
                   (list name url description)))
                 remotes-map)))
 #+end_src


### PR DESCRIPTION
Rewrite of `episteme:load-remotes`, now `episteme--load-remotes`, to support the use of the `-ssh` flag. Also renamed internal functions to comply with naming conventions.